### PR TITLE
Better memory usage display for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cupidfetch


### PR DESCRIPTION
Reads from `/proc/meminfo` similarly to what `neofetch` does. Being compatible only with Linux isn't a very big problem since `sysinfo(2)` is also a feature of the kernel. It may be useful to add a more portable fallback though, but not much is lost with this change other than old versions of Linux.

# Notes

- `CLEANUP:` may be useless