### PR TITLE
Add Battery Support, Improve WM Detection, and Enhance Distro Detection

### DIFF
--- a/install-config.sh
+++ b/install-config.sh
@@ -47,7 +47,7 @@ else
 # Default cupidfetch configuration
 
 # List of modules (space-separated)
-modules = hostname username distro linux_kernel uptime pkg term shell de ip memory cpu storage
+modules = hostname username distro linux_kernel uptime pkg term shell wm ip memory cpu storage
 
 # Memory display settings
 memory.unit-str = MB

--- a/install-config.sh
+++ b/install-config.sh
@@ -47,7 +47,7 @@ else
 # Default cupidfetch configuration
 
 # List of modules (space-separated)
-modules = hostname username distro linux_kernel uptime pkg term shell wm ip memory cpu storage
+modules = hostname username distro linux_kernel uptime pkg term shell wm session ip memory cpu storage
 
 # Memory display settings
 memory.unit-str = MB

--- a/install-config.sh
+++ b/install-config.sh
@@ -47,7 +47,7 @@ else
 # Default cupidfetch configuration
 
 # List of modules (space-separated)
-modules = hostname username distro linux_kernel uptime pkg term shell wm session ip memory cpu storage
+modules = hostname username distro linux_kernel uptime pkg term shell wm session ip memory cpu storage battery
 
 # Memory display settings
 memory.unit-str = MB

--- a/src/config.c
+++ b/src/config.c
@@ -22,11 +22,11 @@ struct module string_to_module[] = {
     {"pkg", get_package_count},
     {"term", get_terminal},
     {"shell", get_shell},
-    {"de", get_desktop_environment},
     {"ip", get_local_ip},
     {"memory", get_available_memory},
     {"storage", get_available_storage},
     {"cpu", get_cpu},
+    {"wm", get_window_manager},
 };
 
 void init_g_config() {
@@ -34,8 +34,7 @@ void init_g_config() {
     struct CupidConfig cfg_ = {
         .modules = { get_hostname, get_username, get_distro, get_linux_kernel,
                      get_uptime, get_package_count, get_terminal, get_shell,
-                     get_desktop_environment, get_local_ip, get_available_memory, get_cpu,
-                     get_available_storage,
+                     get_available_storage, get_window_manager,
                      NULL },
         .memory_unit = "MB",
         .memory_unit_size = 1000000,

--- a/src/config.c
+++ b/src/config.c
@@ -28,6 +28,7 @@ struct module string_to_module[] = {
     {"cpu", get_cpu},
     {"wm", get_window_manager},
     {"session", get_session_type},
+    {"battery", get_battery},
 };
 
 void init_g_config() {
@@ -35,7 +36,7 @@ void init_g_config() {
     struct CupidConfig cfg_ = {
         .modules = { get_hostname, get_username, get_distro, get_linux_kernel,
                      get_uptime, get_package_count, get_terminal, get_shell,
-                     get_available_storage, get_window_manager, get_session_type,
+                     get_available_storage, get_window_manager, get_session_type, get_battery,
                      NULL },
         .memory_unit = "MB",
         .memory_unit_size = 1000000,

--- a/src/config.c
+++ b/src/config.c
@@ -27,6 +27,7 @@ struct module string_to_module[] = {
     {"storage", get_available_storage},
     {"cpu", get_cpu},
     {"wm", get_window_manager},
+    {"session", get_session_type},
 };
 
 void init_g_config() {
@@ -34,7 +35,7 @@ void init_g_config() {
     struct CupidConfig cfg_ = {
         .modules = { get_hostname, get_username, get_distro, get_linux_kernel,
                      get_uptime, get_package_count, get_terminal, get_shell,
-                     get_available_storage, get_window_manager,
+                     get_available_storage, get_window_manager, get_session_type,
                      NULL },
         .memory_unit = "MB",
         .memory_unit_size = 1000000,

--- a/src/cupidfetch.h
+++ b/src/cupidfetch.h
@@ -19,6 +19,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
+#define _GNU_SOURCE
 #define MAX_NUM_MODULES 30
 #define CONFIG_PATH_SIZE 256
 #define LINUX_PROC_LINE_SZ 128
@@ -39,6 +40,12 @@ typedef enum {
     LogType_CRITICAL = 3
 } LogType;
 
+enum session_kind {
+    SESSION_UNKNOWN = 0,
+    SESSION_X11,
+    SESSION_WAYLAND
+};
+
 // print.c
 int get_terminal_width();
 void print_info(const char *key, const char *format, int align_key, int align_value, ...);
@@ -58,8 +65,16 @@ void get_local_ip();
 void get_available_memory();
 void get_cpu();
 void get_available_storage();
+void get_window_manager();
 const char* get_home_directory();
 
+
+/* Returns detected session kind based on env vars. */
+enum session_kind detect_session_kind(void);
+
+/* Fills buf with the active WM/compositor name (e.g., "i3", "KWin", "sway", "Hyprland").
+   Returns 1 on success, 0 if unknown. */
+int detect_window_manager(char *buf, size_t buflen);
 // config.c
 extern struct CupidConfig g_userConfig;
 void init_g_config();

--- a/src/cupidfetch.h
+++ b/src/cupidfetch.h
@@ -68,6 +68,7 @@ void get_available_storage();
 void get_window_manager();
 const char* get_home_directory();
 void get_session_type();
+void get_battery();
 
 /* Returns detected session kind based on env vars. */
 enum session_kind detect_session_kind(void);

--- a/src/cupidfetch.h
+++ b/src/cupidfetch.h
@@ -67,7 +67,7 @@ void get_cpu();
 void get_available_storage();
 void get_window_manager();
 const char* get_home_directory();
-
+void get_session_type();
 
 /* Returns detected session kind based on env vars. */
 enum session_kind detect_session_kind(void);

--- a/src/modules.c
+++ b/src/modules.c
@@ -297,6 +297,19 @@ enum session_kind detect_session_kind(void) {
     return SESSION_UNKNOWN;
 }
 
+void get_session_type() {
+    enum session_kind kind = detect_session_kind();
+    const char *session_str = "Unknown";
+
+    switch (kind) {
+        case SESSION_X11:     session_str = "X11";     break;
+        case SESSION_WAYLAND: session_str = "Wayland"; break;
+        case SESSION_UNKNOWN: session_str = "Unknown"; break;
+    }
+
+    print_info("Session", "%s", 20, 30, session_str);
+}
+
 /* --- X11 (EWMH) path --- */
 #if defined(HAVE_X11) || defined(USE_X11)
 static int get_wm_name_x11(char *buf, size_t buflen) {


### PR DESCRIPTION
### **Summary**

This PR introduces three major improvements to `cupidfetch`:

1. **Battery Status Module**

   * Adds a robust `get_battery()` implementation that:

     * Detects all batteries under `/sys/class/power_supply`
     * Uses `energy_now/energy_full` or `charge_now/charge_full` pairs to compute an **aggregate percentage**
     * Falls back to averaging `capacity` files if needed
     * Displays charging/discharging/full status alongside percentage
   * Automatically handles multiple battery setups (e.g. ThinkPads with removable + internal batteries)
   * Prints `Battery: N/A` on desktops or systems with no batteries

2. **Improved Window Manager Detection**

   * Expands Wayland environment detection with support for:

     * **COSMIC**, **River**, **Labwc**, **Wayfire**, **Weston**
   * Adds process fallbacks for `kwin_wayland`, `Hyprland`, `gnome-shell`, etc.
   * Prioritizes native Wayland compositors but gracefully falls back to X11 if running nested

3. **Better Distro + Package Detection**

   * Enhances `detect_pkg_count_cmd()` with broader family coverage:

     * Adds detection for Alpine, Artix, EndeavourOS, Gentoo (equery/qlist fallback), Void, Solus, Slackware, NixOS, Guix, Clear Linux, TinyCore, Bedrock Linux
   * Dynamically auto-adds unknown distros to `data/distros.def` with detected package manager command
   * Improves `/etc/os-release` parsing by using `PRETTY_NAME` when available, or assembling `NAME + VERSION_ID (+codename)`